### PR TITLE
Removed WikiHow from config description

### DIFF
--- a/scheduler/src/templates/stripe/shop.html
+++ b/scheduler/src/templates/stripe/shop.html
@@ -341,7 +341,7 @@ window.onresize = onframeresize;
           <section class="description">
             <ul>
               <li>Dozens of resources on homesteading, water treatment, military and emergency medicine, <em>etc.</em></li>
-              <li>WikiHow, iFixit, and other repair resources</li>
+              <li>iFixit, and other repair resources</li>
               <li>The entire Wikipedia</li>
               <li>TrailSense and Survival apps for Android, ready to download</li>
               <li>Fits on a 256 GB microSD card. See demo <a target="_blank" href="https://preppers.demo.hotspot.kiwix.org/">here</a>.</li>


### PR DESCRIPTION
Since WikiHow zim files are not available anymore I have removed it from the sales page.